### PR TITLE
refactor(cargo): specify the matching tag for dependency memchr again…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ std = ["memchr/use_std"]
 mesalock_sgx = ["sgx_tstd", "memchr/mesalock_sgx"]
 
 [dependencies]
-memchr = { git = "https://github.com/mesalock-linux/rust-memchr-sgx", version = "2.2.0", default-features = false }
+memchr = { git = "https://github.com/mesalock-linux/rust-memchr-sgx", version = "2.2.0", default-features = false, tag = "sgx_1.1.0" }
 sgx_tstd = { rev = "v1.1.0", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
It's to avoid the breaking due to the future upgrading teaclave-sgx-sdk, which triggers a horrible collapse of SGX-based crates during upgrading teaclave-sgx-sdk from v1.0.9 to v1.1.0